### PR TITLE
Add a .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,16 @@
+###Java###
+
+*.class
+
+# Mobile Tools for Java (J2ME)
+.mtj.tmp/
+
+# Package Files #
+*.jar
+*.war
+*.ear
+
+# virtual machine crash logs, see http://www.java.com/en/download/help/error_hotspot.xml
+hs_err_pid*
+
+accounts.txt


### PR DESCRIPTION
A .gitignore was necessary to avoid having git track unncecessary files like
the compiled bytecode and the accounts.txt file.

Signed-off-by: Vickz84259 <vickz84259@gmail.com>